### PR TITLE
Update CODEOWNERS: remove deprecated group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 
 # *  @bretbrownjr @camio @dietmarkuehl @neatudarius @steve-downey @wusatosi @bemanproject/core-reviewers
 
-* @wermos @wusatosi @bemanproject/core-reviewers
+* @wermos @wusatosi


### PR DESCRIPTION
Update CODEOWNERS: remove deprecated group https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#repositorycodeowners

