### PR TITLE
Fix readme.license from Beman Standard in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ This project officially supports:
 
 beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
 
-
 ## Development
 
 ### Develop using GitHub Codespace

--- a/README.md
+++ b/README.md
@@ -80,10 +80,6 @@ This project officially supports:
 > (e.g. HEAD/nightly).
 > These development environments are verified using our CI configuration.
 
-## License
-
-beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
-
 ## Development
 
 ### Develop using GitHub Codespace

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ int main() {
 
 Full runnable examples can be found in [`examples/`](examples/).
 
+## License
+
+beman.indices_view is licensed under the Apache License v2.0 with LLVM Exceptions.
+
 ## Dependencies
 
 ### Build Environment

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ This project officially supports:
 > (e.g. HEAD/nightly).
 > These development environments are verified using our CI configuration.
 
+## License
+
+beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
+
+
 ## Development
 
 ### Develop using GitHub Codespace


### PR DESCRIPTION
[bemanproject/beman-tidy#256](https://github.com/orgs/bemanproject/projects/8/views/1?pane=issue&itemId=179205905&issue=bemanproject%7Cbeman-tidy%7C256)
Fix readme.license from Beman Standard in README.md

beman-tidy status before this PR:
```bash
Running check [Requirement][readme.license] ...
[error][readme.license]: The file 'README.md' does not contain a `## License` section. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmelicense.
        check [Requirement][readme.license] ... failed
```
beman-tidy status before this PR:
```bash
Running check [Requirement][readme.license] ...
              check [Requirement][readme.license] ... passed
```
