### PR TITLE
Fix license.apache_llvm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-==============================================================================
-The Beman Project is under the Apache License v2.0 with LLVM Exceptions:
-==============================================================================
 
                                  Apache License
                            Version 2.0, January 2004
@@ -220,15 +217,3 @@ conflicts with the conditions of the GPLv2, you may retroactively and
 prospectively choose to deem waived or otherwise exclude such Section(s) of
 the License, but only in their entirety and only with respect to the Combined
 Software.
-
-==============================================================================
-Software from third parties included in the Beman Project:
-==============================================================================
-The Beman Project contains third party software which is under different license
-terms. All such code will be identified clearly using at least one of two
-mechanisms:
-1) It will be in a separate directory tree with its own `LICENSE.txt` or
-   `LICENSE` file at the top containing the specific license and restrictions
-   which apply to that software, or
-2) It will contain specific license and restriction terms at the top of every
-   file.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ This project officially supports:
 > (e.g. HEAD/nightly).
 > These development environments are verified using our CI configuration.
 
-
 ## Development
 
 ### Develop using GitHub Codespace

--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ This project officially supports:
 > (e.g. HEAD/nightly).
 > These development environments are verified using our CI configuration.
 
-## License
-
-beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ This project officially supports:
 > (e.g. HEAD/nightly).
 > These development environments are verified using our CI configuration.
 
+## License
+
+beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
+
 ## Development
 
 ### Develop using GitHub Codespace


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/256

update LICENSE: remove Beman extra information

before:
``
Running check [Requirement][license.apache_llvm] ...
[error][license.apache_llvm]: Please update the LICENSE file to include the Apache License v2.0 with LLVM Exceptions. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#licenseapache_llvm for more information.
        check [Requirement][license.apache_llvm] ... failed
``

after:
``
Running check [Requirement][license.apache_llvm] ...
        check [Requirement][license.apache_llvm] ... passed
``