### PR TITLE
Fix standard_target in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ![Continuous Integration Tests](https://github.com/bemanproject/indices_view/actions/workflows/ci_tests.yml/badge.svg)
 ![Lint Check (pre-commit)](https://github.com/bemanproject/indices_view/actions/workflows/pre-commit.yml/badge.svg)
 ![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
-
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
 **Implements**: `std::views::indices` proposed in [Add std::views::indices(n) (P3060R2)](https://wg21.link/P3060R2).
 
 **Status**: [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_production_ready_stable_api.svg)
 ![Continuous Integration Tests](https://github.com/bemanproject/indices_view/actions/workflows/ci_tests.yml/badge.svg)
 ![Lint Check (pre-commit)](https://github.com/bemanproject/indices_view/actions/workflows/pre-commit.yml/badge.svg)
-![Target Standard](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
-![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 **Implements**: `std::views::indices` proposed in [Add std::views::indices(n) (P3060R2)](https://wg21.link/P3060R2).
 
 **Status**: [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api)


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/256

Modify README.md from [Target Standard] to [Standard Target]

before:
``
Running check [Requirement][readme.badges] ...
[error][readme.badges]: The file 'README.md' does not contain exactly one required badge of category 'standard_target'.
        check [Requirement][readme.badges] ... failed
``

after:
``
Running check [Requirement][readme.badges] ...
        check [Requirement][readme.badges] ... passed
``