### PR TITLE
Upgrade `actions/checkout`, `actions/setup-python`, `tj-actions/changed-files` to newer versions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -95,7 +95,7 @@ jobs:
               ${{ matrix.cmake_args.description }}"
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Ninja
         uses: lukka/get-cmake@latest
         with:
@@ -170,7 +170,7 @@ jobs:
             toolchain: "infra/cmake/llvm-toolchain.cmake"
     name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup build environment
         uses: lukka/get-cmake@latest
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,9 +22,8 @@ jobs:
           python-version: 3.13
 
         # We wish to run pre-commit on all files instead of the changes
-        # only made in the push commit.
-        #
-        # So linting error persists when there's formatting problem.
+        # only made in the push commit so that linting error persists
+        # when there's formatting problem.
       - uses: pre-commit/action@v3.0.1
 
   pre-commit-pr:
@@ -42,8 +41,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-        # pull_request_target checkout the base of the repo
-        # We need to checkout the actual pr to lint the changes.
+        # pull_request_target checks out the base of the repo
+        # We need to checkout the actual PR to lint the changes.
       - name: Checkout pr
         run: gh pr checkout ${{ github.event.number }}
         env:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
 
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
         # pull_request_target checks out the base of the repo
         # We need to checkout the actual PR to lint the changes.
@@ -49,14 +49,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
 
         # we only lint on the changed file in PR.
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
 
         # See:
         # https://github.com/tj-actions/changed-files?tab=readme-ov-file#using-local-git-directory-


### PR DESCRIPTION
<!--
Thank you for your contribution!

If you are updating project structure or build configs:
- Make sure your contribution conforms to the Beman Standard:
  https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md
- For new CMake arguments / presets: please make sure you added appropriate CI tests.

If you are updating documentation:
- Make sure badges and pictures does not impact readability.

If you are updating implementations:
- Make sure you submit appropriate testing.

We encourage small and incremental additions instead of large redesigns.
They are easier and faster to review.
They are also less likely to introduce bugs.

While we do not formally adopt this guide as a standard,
we encourage you to read and consider:
"The CL author’s guide to getting through code review".
https://google.github.io/eng-practices/review/developer/

Regardless, feel free to open a PR on your existing changes.
We appreciate the suggestion and will help out.

Please run pre-commit against your change to comply with our linting rules.
The command to check all files in the directory is:
$ pre-commit run --all-files
-->

<!-- markdownlint-disable-next-line MD041 -->
## Description

When GitHub Actions runs, the following warning is emitted:

> **Pre-Commit check on PR**
>
> `Node.js` 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@v4`, `actions/checkout@v4`, `actions/setup-python@v5`, `tj-actions/changed-files@v45`. Actions will be forced to run with `Node.js` 24 by default starting June 2nd, 2026. `Node.js` 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support `Node.js` 24. To opt into `Node.js` 24 now, set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable on the runner or in your workflow file. Once `Node.js` 24 becomes the default, you can temporarily opt out by setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true`. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

For this reason, I upgraded
- `actions/checkout` from `v4` to `v6`,
- `actions/setup-python` from `v5` to `v6`,
- `tj-actions/changed-files` from `v45` to `v47`.

- [ ] If all approvals are obtained and the PR is green, any Beman member can merge the PR.

<!-- make sure you run pre-commit before opening a PR -->
